### PR TITLE
Sidekiq 4.0 friendly fetch

### DIFF
--- a/lib/sidekiq/hostname_fetch/strategy.rb
+++ b/lib/sidekiq/hostname_fetch/strategy.rb
@@ -5,8 +5,13 @@ module Sidekiq
   module HostnameFetch
     class Strategy < ::Sidekiq::BasicFetch
       def initialize(options)
-        super
-        @queues = @queues.map { |q| [q, "#{q}_host_#{current_hostname}"] }.flatten
+        @strictly_ordered_queues = !!options[:strict]
+        @queues = options[:queues].map { |q| "queue:#{q}" }
+        @queues.unshift *@queues.map { |q| "#{q}_host_#{current_hostname}" }
+        if @strictly_ordered_queues
+          @queues = @queues.uniq
+          @queues << TIMEOUT
+        end
       end
 
       private

--- a/lib/sidekiq/hostname_fetch/strategy.rb
+++ b/lib/sidekiq/hostname_fetch/strategy.rb
@@ -1,4 +1,3 @@
-require 'celluloid'
 require 'sidekiq'
 require 'sidekiq/fetch'
 
@@ -6,11 +5,8 @@ module Sidekiq
   module HostnameFetch
     class Strategy < ::Sidekiq::BasicFetch
       def initialize(options)
-        @strictly_ordered_queues = !!options[:strict]
-        @queues = options[:queues].map { |q| "queue:#{q}" }
+        super
         @queues = @queues.map { |q| [q, "#{q}_host_#{current_hostname}"] }.flatten
-
-        @unique_queues = @queues.uniq
       end
 
       private

--- a/sidekiq-hostname_fetch.gemspec
+++ b/sidekiq-hostname_fetch.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'sidekiq', '>= 2.6.5', '< 4'
+  spec.add_dependency 'sidekiq', '>= 2.6.5', '< 5'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'rspec'

--- a/sidekiq-hostname_fetch.gemspec
+++ b/sidekiq-hostname_fetch.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'sidekiq', '>= 2.6.5', '< 3'
+  spec.add_dependency 'sidekiq', '>= 2.6.5', '< 4'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency 'rspec'

--- a/spec/sidekiq/strategy_spec.rb
+++ b/spec/sidekiq/strategy_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Sidekiq::HostnameFetch::Strategy do
-  let(:options) {{ queues: queues }}
   let(:queues) { %w(queue1 queue1 queue2 queue2) }
+  let(:options) {{ queues: queues }}
 
   it do
     allow_any_instance_of(described_class).to receive(:current_hostname).and_return("job-01.rspec-runner.com")
@@ -10,9 +10,8 @@ describe Sidekiq::HostnameFetch::Strategy do
 
     fetcher_queues = fetcher.instance_variable_get("@queues")
 
-    queues_with_hostname = queues.map do |q|
-      ["queue:#{q}", "queue:#{q}_host_job-01.rspec-runner.com"]
-    end.flatten
-    expect(fetcher_queues).to eq(queues_with_hostname)
+    queues_with_hostname = queues.map { |q| "queue:#{q}_host_job-01.rspec-runner.com" }
+    queues_without_hostname = queues.map { |q| "queue:#{q}" }
+    expect(fetcher_queues).to eq(queues_with_hostname + queues_without_hostname)
   end
 end

--- a/spec/sidekiq/strategy_spec.rb
+++ b/spec/sidekiq/strategy_spec.rb
@@ -5,7 +5,7 @@ describe Sidekiq::HostnameFetch::Strategy do
   let(:queues) { %w(queue1 queue1 queue2 queue2) }
 
   it do
-    described_class.any_instance.stub(:current_hostname).and_return("job-01.rspec-runner.com")
+    allow_any_instance_of(described_class).to receive(:current_hostname).and_return("job-01.rspec-runner.com")
     fetcher = described_class.new(options)
 
     fetcher_queues = fetcher.instance_variable_get("@queues")

--- a/spec/sidekiq/worker_spec.rb
+++ b/spec/sidekiq/worker_spec.rb
@@ -13,7 +13,7 @@ describe Sidekiq::Worker do
 
   describe "#perform_async_on_host" do
     it do
-      TestWorker.should_receive(:client_push).with do |args|
+      allow_any_instance_of(TestWorker).to receive(:client_push).with do |args|
         expect(args["args"]).to eq(["arg1","arg2"])
         expect(args["queue"]).to eq("important_host_custom_host")
       end
@@ -23,9 +23,9 @@ describe Sidekiq::Worker do
 
   describe "#perform_async_on_current_host" do
     it do
-      TestWorker.stub(:current_hostname).and_return("job-01.rspec-runner.com")
+      allow_any_instance_of(TestWorker).to receive(:current_hostname).and_return('job-01.rspec-runner.com')
 
-      TestWorker.should_receive(:client_push).with do |args|
+      allow_any_instance_of(TestWorker).to receive(:client_push).with do |args|
         expect(args["args"]).to eq(["arg1","arg2"])
         expect(args["queue"]).to eq("important_host_job-01.rspec-runner.com")
       end
@@ -35,7 +35,7 @@ describe Sidekiq::Worker do
 
   describe "#perform_in_on_host" do
     it do
-      TestWorker.should_receive(:client_push).with do |args|
+      allow_any_instance_of(TestWorker).to receive(:client_push).with do |args|
         expect(args["args"]).to eq(["arg1","arg2"])
         expect(args["at"]).to be_within(1).of(current_time.to_i)
         expect(args["queue"]).to eq("important_host_custom_host")
@@ -46,7 +46,7 @@ describe Sidekiq::Worker do
 
   describe "#perform_at_on_host" do
     it do
-      TestWorker.should_receive(:client_push).with do |args|
+      allow_any_instance_of(TestWorker).to receive(:client_push).with do |args|
         expect(args["args"]).to eq(["arg1","arg2"])
         expect(args["at"]).to be_within(1).of(current_time.to_i)
         expect(args["queue"]).to eq("important_host_custom_host")
@@ -57,9 +57,9 @@ describe Sidekiq::Worker do
 
   describe "workers with host_specific option" do
     it do
-      TestWorker.stub(:current_hostname).and_return("job-01.rspec-runner.com")
+      allow_any_instance_of(TestWorker).to receive(:current_hostname).and_return('job-01.rspec-runner.com')
 
-      TestWorker.should_receive(:client_push).with do |args|
+      allow_any_instance_of(TestWorker).to receive(:client_push).with do |args|
         expect(args["args"]).to eq(["arg1","arg2"])
         expect(args["queue"]).to eq("important_host_job-01.rspec-runner.com")
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'sidekiq/hostname_fetch'
-require 'celluloid/autostart'
 require 'sidekiq/fetch'
 
 Sidekiq.logger = nil


### PR DESCRIPTION
Drops celluloid from requirements and updates strategy initialization process

However configuration does not happen the way it is told in the README

We needed to force it like this 

`Sidekiq.options = Sidekiq.options.merge(fetch: Sidekiq::HostnameFetch::Strategy)`

not sure if it is too ugly.
